### PR TITLE
feat: HTTP consolidation, no-agent preset, CI dual-release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,12 +121,116 @@ jobs:
           path: ${{ env.IDASDK }}/src/bin/idasql.exe
 
   # ============================================================================
+  # Build no-agent variant (CLI + Plugin) — lightweight HTTP-only, no AI deps
+  # ============================================================================
+  build-linux-no-agent:
+    name: Build no-agent (Linux)
+    runs-on: ubuntu-latest
+    env:
+      IDASDK: ${{ github.workspace }}/ida-sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup IDA SDK
+        run: git clone --depth 1 --recurse-submodules https://github.com/HexRaysSA/ida-sdk ida-sdk
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DIDASQL_WITH_AI_AGENT=OFF
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Upload plugin (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-no-agent-linux
+          path: ${{ env.IDASDK }}/src/bin/plugins/idasql.so
+
+      - name: Upload CLI (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-no-agent-linux
+          path: ${{ env.IDASDK }}/src/bin/idasql
+
+  build-macos-no-agent:
+    name: Build no-agent (macOS)
+    runs-on: macos-latest
+    env:
+      IDASDK: ${{ github.workspace }}/ida-sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup IDA SDK
+        run: git clone --depth 1 --recurse-submodules https://github.com/HexRaysSA/ida-sdk ida-sdk
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DIDASQL_WITH_AI_AGENT=OFF
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Upload plugin (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-no-agent-macos
+          path: ${{ env.IDASDK }}/src/bin/plugins/idasql.dylib
+
+      - name: Upload CLI (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-no-agent-macos
+          path: ${{ env.IDASDK }}/src/bin/idasql
+
+  build-windows-no-agent:
+    name: Build no-agent (Windows)
+    runs-on: windows-latest
+    env:
+      IDASDK: ${{ github.workspace }}/ida-sdk
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout submodules
+        shell: bash
+        run: git submodule update --init --recursive
+
+      - name: Setup IDA SDK
+        shell: bash
+        run: git clone --depth 1 --recurse-submodules https://github.com/HexRaysSA/ida-sdk ida-sdk
+
+      - name: Configure
+        run: cmake -B build -DIDASQL_WITH_AI_AGENT=OFF
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Upload plugin (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-no-agent-windows
+          path: ${{ env.IDASDK }}/src/bin/plugins/idasql.dll
+
+      - name: Upload CLI (no-agent)
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-no-agent-windows
+          path: ${{ env.IDASDK }}/src/bin/idasql.exe
+
+  # ============================================================================
   # Release
   # ============================================================================
   publish-release:
     name: Publish Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [build-linux, build-macos, build-windows]
+    needs: [build-linux, build-macos, build-windows, build-linux-no-agent, build-macos-no-agent, build-windows-no-agent]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -139,49 +243,88 @@ jobs:
           path: plugins
           merge-multiple: true
 
-      - name: Download CLI (Linux)
+      - name: Download CLI (with agent)
         uses: actions/download-artifact@v4
         with:
-          name: cli-linux
+          pattern: cli-linux
           path: cli-linux
-
-      - name: Download CLI (macOS)
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           name: cli-macos
           path: cli-macos
-
-      - name: Download CLI (Windows)
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           name: cli-windows
           path: cli-windows
 
+      - name: Download no-agent plugins
+        uses: actions/download-artifact@v4
+        with:
+          pattern: plugin-no-agent-*
+          path: plugins-no-agent
+          merge-multiple: true
+
+      - name: Download CLI (no agent)
+        uses: actions/download-artifact@v4
+        with:
+          name: cli-no-agent-linux
+          path: cli-no-agent-linux
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-no-agent-macos
+          path: cli-no-agent-macos
+      - uses: actions/download-artifact@v4
+        with:
+          name: cli-no-agent-windows
+          path: cli-no-agent-windows
+
       - name: Prepare release
         run: |
-          mkdir -p release/plugin
+          mkdir -p release/plugin release/plugin-no-agent
           mkdir -p release/cli/{windows,linux,macos}
-          # Plugin (flat, IDA-compatible)
+          mkdir -p release/cli-no-agent/{windows,linux,macos}
+          # Plugin with agent (flat, IDA-compatible)
           cp plugins/idasql.dll release/plugin/ || true
           cp plugins/idasql.so release/plugin/ || true
           cp plugins/idasql.dylib release/plugin/ || true
           cp ida-plugin.json release/plugin/
-          # CLI (organized by platform)
+          # Plugin without agent (flat, IDA-compatible)
+          cp plugins-no-agent/idasql.dll release/plugin-no-agent/ || true
+          cp plugins-no-agent/idasql.so release/plugin-no-agent/ || true
+          cp plugins-no-agent/idasql.dylib release/plugin-no-agent/ || true
+          cp ida-plugin.json release/plugin-no-agent/
+          # CLI with agent (organized by platform)
           cp cli-windows/idasql.exe release/cli/windows/ || true
           cp cli-linux/idasql release/cli/linux/ || true
           cp cli-macos/idasql release/cli/macos/ || true
+          # CLI without agent (organized by platform)
+          cp cli-no-agent-windows/idasql.exe release/cli-no-agent/windows/ || true
+          cp cli-no-agent-linux/idasql release/cli-no-agent/linux/ || true
+          cp cli-no-agent-macos/idasql release/cli-no-agent/macos/ || true
           echo "=== Plugin ===" && ls -la release/plugin/
-          echo "=== CLI ===" && ls -laR release/cli/
+          echo "=== Plugin (no-agent) ===" && ls -la release/plugin-no-agent/
+          echo "=== CLI (agent) ===" && ls -laR release/cli/
+          echo "=== CLI (no-agent) ===" && ls -laR release/cli-no-agent/
 
       - name: Create plugin zip
         run: |
           cd release/plugin
           zip -9 ../idasql_plugin-${{ github.ref_name }}.zip *
 
-      - name: Create CLI zip
+      - name: Create plugin zip (no agent)
+        run: |
+          cd release/plugin-no-agent
+          zip -9 ../idasql_plugin-no-agent-${{ github.ref_name }}.zip *
+
+      - name: Create CLI zip (with agent)
         run: |
           cd release/cli
           zip -r9 ../idasql_cli-${{ github.ref_name }}.zip windows linux macos
+
+      - name: Create CLI zip (no agent)
+        run: |
+          cd release/cli-no-agent
+          zip -r9 ../idasql_cli-no-agent-${{ github.ref_name }}.zip windows linux macos
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
@@ -191,4 +334,6 @@ jobs:
           generate_release_notes: true
           files: |
             release/idasql_plugin-${{ github.ref_name }}.zip
+            release/idasql_plugin-no-agent-${{ github.ref_name }}.zip
             release/idasql_cli-${{ github.ref_name }}.zip
+            release/idasql_cli-no-agent-${{ github.ref_name }}.zip

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "release",
+      "displayName": "Release",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "IDASQL_WITH_AI_AGENT": "ON"
+      }
+    },
+    {
+      "name": "release-no-agent",
+      "displayName": "Release (no AI agent)",
+      "description": "Build without AI agent support to reduce binary size. Excludes libagents, fastmcpp, claude_sdk, copilot_sdk_cpp, easywsclient, tiny-process-library.",
+      "generator": "Visual Studio 17 2022",
+      "binaryDir": "${sourceDir}/build-no-agent",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "IDASQL_WITH_AI_AGENT": "OFF"
+      }
+    }
+  ]
+}

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -2,9 +2,9 @@
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
     "name": "IDASQL",
-    "version": "0.0.1",
+    "version": "0.0.8",
     "entryPoint": "idasql",
-    "description": "SQL interface for IDA databases. Query functions, xrefs, strings, types, and more using SQL. Supports local CLI, remote server mode, and natural language queries via Claude.",
+    "description": "SQL interface for IDA databases. Query functions, xrefs, strings, types, and more using SQL. Supports local CLI, HTTP REST server, and optional AI agent integration.",
     "urls": {
       "repository": "https://github.com/allthingsida/idasql"
     },

--- a/prompts/idasql_agent.md
+++ b/prompts/idasql_agent.md
@@ -2343,7 +2343,6 @@ idasql -s database.i64 --http 8081 --token mysecret
 | `/help` | GET | No | API documentation (for LLM discovery) |
 | `/query` | POST | Yes* | Execute SQL (body = raw SQL) |
 | `/status` | GET | Yes* | Health check |
-| `/health` | GET | Yes* | Alias for /status |
 | `/shutdown` | POST | Yes* | Stop server |
 
 *Auth required only if `--token` was specified.

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -77,14 +77,17 @@ target_sources(idasql_cli PRIVATE
 )
 target_compile_definitions(idasql_cli PRIVATE XSQL_HAS_THINCLIENT)
 
-# Fetch cpp-httplib if not already available
-include(FetchContent)
-FetchContent_Declare(
-    cpp_httplib
-    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-    GIT_TAG v0.15.3
-)
-FetchContent_MakeAvailable(cpp_httplib)
-target_include_directories(idasql_cli PRIVATE ${cpp_httplib_SOURCE_DIR})
+# cpp-httplib: provided transitively by xsql::xsql when XSQL_WITH_THINCLIENT=ON.
+# Only fetch standalone if the target doesn't already exist (e.g. standalone build).
+if(NOT TARGET httplib)
+    include(FetchContent)
+    FetchContent_Declare(
+        cpp_httplib
+        GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+        GIT_TAG v0.15.3
+    )
+    FetchContent_MakeAvailable(cpp_httplib)
+    target_include_directories(idasql_cli PRIVATE ${cpp_httplib_SOURCE_DIR})
+endif()
 
 # idasql.exe is placed next to ida.exe via RUNTIME_OUTPUT_DIRECTORY above.

--- a/src/common/http_server.cpp
+++ b/src/common/http_server.cpp
@@ -1,22 +1,6 @@
 #include "http_server.hpp"
 
-// Windows SDK compatibility for cpp-httplib
-#ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#endif
-
-#include <httplib.h>
-#include <xsql/json.hpp>
-
-#include <chrono>
-#include <random>
 #include <sstream>
-#include <thread>
 
 namespace idasql {
 
@@ -31,7 +15,6 @@ Endpoints:
   GET  /help     - This documentation
   POST /query    - Execute SQL (body = raw SQL, response = JSON)
   GET  /status   - Server health check
-  GET  /health   - Alias for /status
   POST /shutdown - Stop server
 
 Response Format:
@@ -43,286 +26,60 @@ Example:
   curl -X POST http://localhost:<port>/query -d "SELECT name FROM funcs LIMIT 5"
 )";
 
-class IDAHTTPServer::Impl {
-public:
-    httplib::Server svr;
-    std::thread server_thread;
-};
-
-IDAHTTPServer::IDAHTTPServer() = default;
-
-IDAHTTPServer::~IDAHTTPServer() {
-    stop();
-}
-
-std::string IDAHTTPServer::queue_and_wait(const std::string& sql) {
-    if (!running_.load()) {
-        return xsql::json{{"success", false}, {"error", "Server not running"}}.dump();
-    }
-
-    auto cmd = std::make_shared<HTTPPendingCommand>();
-    cmd->sql = sql;
-    cmd->completed = false;
-
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        pending_commands_.push(cmd);
-    }
-    queue_cv_.notify_one();
-
-    // Wait for completion with timeout
-    {
-        std::unique_lock<std::mutex> lock(cmd->done_mutex);
-        int wait_count = 0;
-        while (!cmd->completed && wait_count < 600) {  // 60 seconds max
-            cmd->done_cv.wait_for(lock, std::chrono::milliseconds(100));
-            wait_count++;
-        }
-        if (!cmd->completed) {
-            return xsql::json{{"success", false}, {"error", "Request timed out"}}.dump();
-        }
-    }
-
-    return cmd->result;
-}
-
 int IDAHTTPServer::start(int port, HTTPQueryCallback query_cb,
                          const std::string& bind_addr, bool use_queue) {
-    if (running_.load()) {
-        return port_;
+    if (impl_ && impl_->is_running()) {
+        return impl_->port();
     }
 
-    query_cb_ = query_cb;
-    bind_addr_ = bind_addr;
-    use_queue_.store(use_queue);
+    xsql::thinclient::http_query_server_config config;
+    config.tool_name = "idasql";
+    config.help_text = HTTP_HELP_TEXT;
+    config.port = port;
+    config.bind_address = bind_addr;
+    config.query_fn = std::move(query_cb);
+    config.use_queue = use_queue;
+    config.status_fn = []() {
+        return xsql::json{{"mode", "repl"}};
+    };
 
-    // If port is 0, pick a random port in the 8100-8199 range
-    if (port == 0) {
-        std::random_device rd;
-        std::mt19937 gen(rd());
-        std::uniform_int_distribution<> dis(8100, 8199);
-        port = dis(gen);
-    }
-
-    impl_ = std::make_unique<Impl>();
-
-    // Set up routes
-    auto& svr = impl_->svr;
-
-    svr.Get("/", [port](const httplib::Request&, httplib::Response& res) {
-        std::string welcome = "IDASQL HTTP Server (REPL)\n\nEndpoints:\n"
-            "  GET  /help     - API documentation\n"
-            "  POST /query    - Execute SQL query\n"
-            "  GET  /status   - Health check\n"
-            "  POST /shutdown - Stop server\n\n"
-            "Example: curl -X POST http://localhost:" + std::to_string(port) +
-            "/query -d \"SELECT name FROM funcs LIMIT 5\"\n";
-        res.set_content(welcome, "text/plain");
-    });
-
-    svr.Get("/help", [](const httplib::Request&, httplib::Response& res) {
-        res.set_content(HTTP_HELP_TEXT, "text/plain");
-    });
-
-    // POST /query - Execute SQL
-    svr.Post("/query", [this](const httplib::Request& req, httplib::Response& res) {
-        if (req.body.empty()) {
-            res.status = 400;
-            res.set_content(
-                xsql::json{{"success", false}, {"error", "Empty query"}}.dump(),
-                "application/json");
-            return;
-        }
-
-        std::string result;
-        if (use_queue_.load()) {
-            result = queue_and_wait(req.body);
-        } else {
-            if (!query_cb_) {
-                res.status = 500;
-                res.set_content(
-                    xsql::json{{"success", false}, {"error", "Query callback not set"}}.dump(),
-                    "application/json");
-                return;
-            }
-            result = query_cb_(req.body);
-        }
-        res.set_content(result, "application/json");
-    });
-
-    // GET /status
-    svr.Get("/status", [this](const httplib::Request&, httplib::Response& res) {
-        xsql::json status = {
-            {"success", true},
-            {"status", "ok"},
-            {"tool", "idasql"},
-            {"mode", "repl"}
-        };
-        res.set_content(status.dump(), "application/json");
-    });
-
-    // GET /health (alias)
-    svr.Get("/health", [this](const httplib::Request&, httplib::Response& res) {
-        xsql::json status = {
-            {"success", true},
-            {"status", "ok"},
-            {"tool", "idasql"},
-            {"mode", "repl"}
-        };
-        res.set_content(status.dump(), "application/json");
-    });
-
-    // POST /shutdown
-    svr.Post("/shutdown", [this](const httplib::Request&, httplib::Response& res) {
-        res.set_content(
-            xsql::json{{"success", true}, {"message", "Shutting down"}}.dump(),
-            "application/json");
-        // Schedule stop after response is sent
-        std::thread([this] {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-            stop();
-        }).detach();
-    });
-
-    // Start server in background thread
-    port_ = port;
-    impl_->server_thread = std::thread([this, port]() {
-        impl_->svr.listen(bind_addr_.c_str(), port);
-    });
-
-    // Wait for server to start listening
-    int attempts = 0;
-    while (!impl_->svr.is_running() && attempts < 50) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        attempts++;
-    }
-
-    if (!impl_->svr.is_running()) {
-        impl_->server_thread.detach();
-        impl_.reset();
-        return -1;
-    }
-
-    running_.store(true);
-    return port_;
-}
-
-void IDAHTTPServer::set_interrupt_check(std::function<bool()> check) {
-    interrupt_check_ = check;
+    impl_ = std::make_unique<xsql::thinclient::http_query_server>(config);
+    return impl_->start();
 }
 
 void IDAHTTPServer::run_until_stopped() {
-    while (running_.load()) {
-        if (interrupt_check_ && interrupt_check_()) {
-            stop();
-            break;
-        }
-
-        std::shared_ptr<HTTPPendingCommand> cmd;
-
-        {
-            std::unique_lock<std::mutex> lock(queue_mutex_);
-            if (queue_cv_.wait_for(lock, std::chrono::milliseconds(100),
-                                   [this]() { return !pending_commands_.empty() || !running_.load(); })) {
-                if (!pending_commands_.empty()) {
-                    cmd = pending_commands_.front();
-                    pending_commands_.pop();
-                }
-            }
-        }
-
-        if (cmd) {
-            try {
-                if (query_cb_) {
-                    cmd->result = query_cb_(cmd->sql);
-                } else {
-                    cmd->result = xsql::json{{"success", false}, {"error", "No query handler"}}.dump();
-                }
-            } catch (const std::exception& e) {
-                cmd->result = xsql::json{{"success", false}, {"error", e.what()}}.dump();
-            }
-
-            {
-                std::lock_guard<std::mutex> lock(cmd->done_mutex);
-                cmd->completed = true;
-            }
-            cmd->done_cv.notify_one();
-        }
-    }
+    if (impl_) impl_->run_until_stopped();
 }
 
 void IDAHTTPServer::stop() {
-    running_.store(false);
-    queue_cv_.notify_all();
-    complete_pending_commands(
-        xsql::json{{"success", false}, {"error", "HTTP server stopped"}}.dump());
-
     if (impl_) {
-        if (impl_->svr.is_running()) {
-            impl_->svr.stop();
-        }
-        if (impl_->server_thread.joinable()) {
-            impl_->server_thread.join();
-        }
+        impl_->stop();
+        impl_.reset();
     }
-
-    impl_.reset();
 }
 
-void IDAHTTPServer::complete_pending_commands(const std::string& result) {
-    std::queue<std::shared_ptr<HTTPPendingCommand>> pending;
-    {
-        std::lock_guard<std::mutex> lock(queue_mutex_);
-        std::swap(pending, pending_commands_);
-    }
+bool IDAHTTPServer::is_running() const {
+    return impl_ && impl_->is_running();
+}
 
-    while (!pending.empty()) {
-        auto cmd = pending.front();
-        pending.pop();
-        if (!cmd) continue;
-
-        {
-            std::lock_guard<std::mutex> lock(cmd->done_mutex);
-            if (!cmd->completed) {
-                cmd->result = result;
-                cmd->completed = true;
-            }
-        }
-        cmd->done_cv.notify_one();
-    }
+int IDAHTTPServer::port() const {
+    return impl_ ? impl_->port() : 0;
 }
 
 std::string IDAHTTPServer::url() const {
-    std::ostringstream ss;
-    ss << "http://" << bind_addr_ << ":" << port_;
-    return ss.str();
+    return impl_ ? impl_->url() : "";
+}
+
+void IDAHTTPServer::set_interrupt_check(std::function<bool()> check) {
+    if (impl_) impl_->set_interrupt_check(std::move(check));
 }
 
 std::string format_http_info(int port, const std::string& stop_hint) {
-    std::ostringstream ss;
-    ss << "HTTP server started on port " << port << "\n";
-    ss << "URL: http://127.0.0.1:" << port << "\n\n";
-    ss << "Endpoints:\n";
-    ss << "  GET  /help     - API documentation\n";
-    ss << "  POST /query    - Execute SQL query\n";
-    ss << "  GET  /status   - Health check\n";
-    ss << "  POST /shutdown - Stop server\n\n";
-    ss << "Example:\n";
-    ss << "  curl -X POST http://127.0.0.1:" << port << "/query -d \"SELECT name FROM funcs LIMIT 5\"\n\n";
-    ss << stop_hint << "\n";
-    return ss.str();
+    return xsql::thinclient::format_http_info("idasql", port, stop_hint);
 }
 
 std::string format_http_status(int port, bool running) {
-    std::ostringstream ss;
-    if (running) {
-        ss << "HTTP server running on port " << port << "\n";
-        ss << "URL: http://127.0.0.1:" << port << "\n";
-    } else {
-        ss << "HTTP server not running\n";
-        ss << "Use '.http start' to start\n";
-    }
-    return ss.str();
+    return xsql::thinclient::format_http_status(port, running);
 }
 
 } // namespace idasql

--- a/src/common/idasql_agent_prompt.hpp
+++ b/src/common/idasql_agent_prompt.hpp
@@ -2352,7 +2352,6 @@ idasql -s database.i64 --http 8081 --token mysecret
 | `/help` | GET | No | API documentation (for LLM discovery) |
 | `/query` | POST | Yes* | Execute SQL (body = raw SQL) |
 | `/status` | GET | Yes* | Health check |
-| `/health` | GET | Yes* | Alias for /status |
 | `/shutdown` | POST | Yes* | Stop server |
 
 *Auth required only if `--token` was specified.

--- a/src/plugin/CMakeLists.txt
+++ b/src/plugin/CMakeLists.txt
@@ -78,12 +78,15 @@ target_include_directories(idasql_plugin PRIVATE
 )
 target_compile_definitions(idasql_plugin PRIVATE XSQL_HAS_THINCLIENT)
 
-# Fetch cpp-httplib if not already available
-include(FetchContent)
-FetchContent_Declare(
-    cpp_httplib
-    GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
-    GIT_TAG v0.15.3
-)
-FetchContent_MakeAvailable(cpp_httplib)
-target_include_directories(idasql_plugin PRIVATE ${cpp_httplib_SOURCE_DIR})
+# cpp-httplib: provided transitively by xsql::xsql when XSQL_WITH_THINCLIENT=ON.
+# Only fetch standalone if the target doesn't already exist.
+if(NOT TARGET httplib)
+    include(FetchContent)
+    FetchContent_Declare(
+        cpp_httplib
+        GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+        GIT_TAG v0.15.3
+    )
+    FetchContent_MakeAvailable(cpp_httplib)
+    target_include_directories(idasql_plugin PRIVATE ${cpp_httplib_SOURCE_DIR})
+endif()


### PR DESCRIPTION
## Summary
- Replace `IDAHTTPServer` with thin wrapper over `xsql::thinclient::http_query_server` from libxsql
- Remove `/health` endpoint (breaking change — use `/status`)
- Add `CMakePresets.json` with `release` and `release-no-agent` presets
- Fix `--http 0` (random port) printing "port 0" instead of actual port
- Guard httplib FetchContent to avoid duplicate target when libxsql already provides it
- CI: build + release no-agent variants (plugin + CLI) alongside agent variants
- Bump `ida-plugin.json` version to 0.0.8

## Release artifacts (4 zips)
- `idasql_plugin-v*.zip` — Plugin with AI agent
- `idasql_plugin-no-agent-v*.zip` — Plugin without AI agent
- `idasql_cli-v*.zip` — CLI with AI agent
- `idasql_cli-no-agent-v*.zip` — CLI without AI agent (pure HTTP + SQL)

## Binary size
| Variant | Size |
|---|---|
| With agent | 3.67 MB |
| No agent | 2.59 MB (-29%) |