### PR TITLE
IDA <9.3 support

### DIFF
--- a/src/lib/include/idasql/decompiler.hpp
+++ b/src/lib/include/idasql/decompiler.hpp
@@ -410,7 +410,11 @@ struct ctree_collector_t : public ctree_parentee_t {
         ci.ea = insn->ea;
         ci.depth = parents.size();
 
+#if IDA_SDK_VERSION >= 930
         citem_t* p = parent_item();
+#else
+        citem_t* p = parents.empty() ? nullptr : parents.back();
+#endif
         if (p) {
             auto it = item_ids.find(p);
             if (it != item_ids.end()) ci.parent_id = it->second;
@@ -433,7 +437,11 @@ struct ctree_collector_t : public ctree_parentee_t {
         ci.ea = expr->ea;
         ci.depth = parents.size();
 
+#if IDA_SDK_VERSION >= 930
         citem_t* p = parent_item();
+#else
+        citem_t* p = parents.empty() ? nullptr : parents.back();
+#endif
         if (p) {
             auto it = item_ids.find(p);
             if (it != item_ids.end()) ci.parent_id = it->second;

--- a/src/lib/include/idasql/entities.hpp
+++ b/src/lib/include/idasql/entities.hpp
@@ -100,8 +100,12 @@ inline bool get_func_tinfo(ea_t ea, tinfo_t& tif) {
     return get_tinfo(&tif, ea);
 }
 
-// Helper to get calling convention name from callcnv_t
+// Helper to get calling convention name
+#if IDA_SDK_VERSION >= 930
 inline const char* get_cc_name(callcnv_t cc) {
+#else
+inline const char* get_cc_name(cm_t cc) {
+#endif
     switch (cc) {
         case CM_CC_CDECL:    return "cdecl";
         case CM_CC_STDCALL:  return "stdcall";

--- a/src/lib/include/idasql/entities_types.hpp
+++ b/src/lib/include/idasql/entities_types.hpp
@@ -1109,7 +1109,11 @@ struct FuncArgEntry {
 
 inline const char* get_calling_convention_name(cm_t cc) {
     // Extract calling convention from cm_t (using CM_CC_MASK)
+#if IDA_SDK_VERSION >= 930
     callcnv_t conv = cc & CM_CC_MASK;
+#else
+    cm_t conv = cc & CM_CC_MASK;
+#endif
     switch (conv) {
         case CM_CC_CDECL: return "cdecl";
         case CM_CC_STDCALL: return "stdcall";

--- a/src/plugin/main.cpp
+++ b/src/plugin/main.cpp
@@ -358,7 +358,11 @@ struct idasql_plugmod_t : public plugmod_t
 static plugmod_t* idaapi init()
 {
     // Skip loading when running under idalib (e.g., idasql CLI)
+#if IDA_SDK_VERSION >= 930
     if (is_ida_library()) {
+#else
+    if (is_ida_library(nullptr, 0, nullptr)) {
+#endif
         msg("IDASQL: Running under idalib, plugin skipped\n");
         return nullptr;
     }


### PR DESCRIPTION
This patch adds IDA_SDK_VERSION checks to fix build errors on versions <9.3, it was tested on version 9.1.250226 for Windows x64