### PR TITLE
fix: crash in UiMessageCapture on ARM64 macOS

### DIFF
--- a/src/lib/src/idapython_exec.cpp
+++ b/src/lib/src/idapython_exec.cpp
@@ -84,15 +84,17 @@ ssize_t idaapi UiMessageCapture::on_event(ssize_t code, va_list va) {
         return 0;
     }
 
-    // On GCC/Clang, va_list is an array type that decays to a pointer when
-    // passed through variadic args. On MSVC, va_list is char* (passed by value).
+    // va_list is an array type on x86-64 System V ABI (__va_list_tag[1]),
+    // so it decays to a pointer when passed through variadic args.
+    // On MSVC and ARM64 Apple (where va_list is char*), it is a scalar
+    // type passed by value — no decay, no extra indirection.
     va_list copy;
-#ifdef _MSC_VER
-    va_list format_args = va_arg(va, va_list);
-    va_copy(copy, format_args);
-#else
+#if defined(__x86_64__) && !defined(_MSC_VER)
     va_list* format_args = va_arg(va, va_list*);
     va_copy(copy, *format_args);
+#else
+    va_list format_args = va_arg(va, va_list);
+    va_copy(copy, format_args);
 #endif
     qstring formatted;
     formatted.vsprnt(format, copy);


### PR DESCRIPTION
## Summary

- `SELECT get_ui_context_json()` crashes IDA on Apple Silicon with a SIGSEGV in `strlen` called from `vsprnt`
- Root cause: `va_list` ABI mismatch in `UiMessageCapture::on_event()` — the code assumed all non-MSVC platforms use array-type `va_list` (which decays to a pointer in variadic calls), but on ARM64 macOS `va_list` is `char*` (scalar, passed by value)
- Dereferencing the wrong type caused string content (`"__IDASQL..."`) to be used as a pointer → SIGSEGV
- Fix: guard the pointer-indirection path with `__x86_64__` (the only platform with array-type `va_list`) instead of `!_MSC_VER`

## Test plan

- [ ] Rebuild plugin on ARM64 macOS, load in IDA, run `SELECT get_ui_context_json()` — should return JSON instead of crashing
- [ ] Verify x86-64 macOS/Linux builds still work (no behavior change on those platforms)
- [ ] Verify MSVC build still works (no change to that code path)