### PR TITLE
fix: simplify RPATH, remove GIT_SHALLOW for pinned hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,6 @@ if(IDASQL_WITH_MCP)
         FetchContent_Declare(fastmcpp
             GIT_REPOSITORY https://github.com/0xeb/fastmcpp.git
             GIT_TAG        4837e8e0a27d0011b73643fe02b3553cd3935c34
-            GIT_SHALLOW    TRUE
         )
         FetchContent_MakeAvailable(fastmcpp)
     endif()

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -39,12 +39,12 @@ if(MSVC)
 elseif(APPLE)
     set_target_properties(idasql_cli PROPERTIES
         BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "@executable_path;$ENV{IDASDK}/src/bin"
+        INSTALL_RPATH "@executable_path/"
     )
 elseif(UNIX)
     set_target_properties(idasql_cli PROPERTIES
         BUILD_WITH_INSTALL_RPATH TRUE
-        INSTALL_RPATH "$ORIGIN;$ENV{IDASDK}/src/bin"
+        INSTALL_RPATH "$ORIGIN"
     )
 endif()
 


### PR DESCRIPTION
## Summary
- Remove `GIT_SHALLOW TRUE` from fastmcpp FetchContent — shallow clones can't resolve pinned commit SHAs
- Simplify macOS/Linux RPATH to `@executable_path/` / `$ORIGIN` only, matching the SDK's GNU make convention. Removes hardcoded `$IDASDK/src/bin` which could resolve to stub dylibs instead of real runtime libraries

Closes #21

## Test plan
- [x] Build: `cmake --build build/cli --target idasql_cli -j8`
- [x] Verify RPATH: `otool -l $IDABIN/idasql | grep -A2 LC_RPATH` shows only `@executable_path/`