### PR TITLE
Fix IDA 9.0–9.2 build: emulate bookmarks_t::get_by_inode() (#35)

### DIFF
--- a/src/lib/src/ida_compat.hpp
+++ b/src/lib/src/ida_compat.hpp
@@ -28,11 +28,13 @@
 //              callcnv_t typedef, GENDSM_UNHIDE,
 //              place_t::equals() (and the idaplace_t__equals runtime export
 //              — shimmed locally in ida_compat.cpp).
-//  9.3 added:  BWN_TITREE (handled via plain `#ifdef`).
+//  9.3 added:  BWN_TITREE (handled via plain `#ifdef`),
+//              bookmarks_t::get_by_inode() (see allthingsida/idasql#35).
 #define IDASQL_HAS_PARENT_ITEM             (IDA_SDK_VERSION >= 920)
 #define IDASQL_HAS_GET_EDM                 (IDA_SDK_VERSION >= 910)
 #define IDASQL_HAS_OPEN_DATABASE_3ARG      (IDA_SDK_VERSION >= 910)
 #define IDASQL_HAS_IS_IDA_LIBRARY_NOARG    (IDA_SDK_VERSION >= 920)
+#define IDASQL_HAS_BOOKMARKS_GET_BY_INODE  (IDA_SDK_VERSION >= 930)
 
 #if IDA_SDK_VERSION < 920
 // callcnv_t was introduced in 9.2 as a distinct type for calling-convention
@@ -86,5 +88,49 @@ inline bool idasql_is_ida_library()
     return is_ida_library();
 #else
     return is_ida_library(nullptr, 0, nullptr);
+#endif
+}
+
+/**
+ * bookmarks_t::get_by_inode() resolves a bookmark dirtree leaf inode to its
+ * store slot, deserializing the location into out_entry and the description
+ * into out_desc. It was added in IDA 9.3; older SDKs expose neither the member
+ * nor the exported bookmarks_t_get_by_inode symbol, so referencing it breaks
+ * both compile and link (see allthingsida/idasql#35).
+ *
+ * Pre-9.3 emulation: the standard bookmark dirtrees key each leaf's inode by
+ * the place's primary coordinate. Verified on 9.3 that idaplace (EA) bookmarks
+ * use inode == ea — the dirtree leaf is even named after the hex ea; tiplace
+ * (local-type) bookmarks mirror this by ordinal. Both call sites only ever pass
+ * real leaf inodes (enumerated via dirtrees::collect_inode_paths), so we scan
+ * the store with the stable size()/get() API and return the slot whose
+ * coordinate matches the inode, leaving out_entry/out_desc populated by get()
+ * exactly as get_by_inode would. is_place_class_ea_capable() distinguishes the
+ * two place classes without constructing one (idalib does not export tiplace's
+ * constructor; we only read members off places get() fills for us).
+ */
+inline uint32 idasql_bookmarks_get_by_inode(
+    lochist_entry_t *out_entry, qstring *out_desc, inode_t inode, void *ud)
+{
+#if IDASQL_HAS_BOOKMARKS_GET_BY_INODE
+    return bookmarks_t::get_by_inode(out_entry, out_desc, inode, ud);
+#else
+    if (out_entry == nullptr || out_entry->place() == nullptr)
+        return BOOKMARKS_BAD_INDEX;
+    const bool ea_capable = is_place_class_ea_capable(out_entry->place()->id());
+    const uint32 count = bookmarks_t::size(*out_entry, ud);
+    for (uint32 slot = 0; slot < count; ++slot)
+    {
+        uint32 idx = slot;
+        if (!bookmarks_t::get(out_entry, out_desc, &idx, ud)
+            || out_entry->place() == nullptr)
+            continue;
+        const uint64 leaf = ea_capable
+            ? uint64(static_cast<idaplace_t *>(out_entry->place())->ea)
+            : uint64(static_cast<tiplace_t *>(out_entry->place())->ordinal);
+        if (leaf == uint64(inode))
+            return idx;
+    }
+    return BOOKMARKS_BAD_INDEX;
 #endif
 }

--- a/src/lib/src/symbols_bookmarks.cpp
+++ b/src/lib/src/symbols_bookmarks.cpp
@@ -28,7 +28,7 @@ void collect_bookmark_rows(std::vector<BookmarkRow> &rows) {
     idaplace_t place(0, 0);
     lochist_entry_t entry(&place, rinfo);
     qstring desc;
-    uint32_t index = bookmarks_t::get_by_inode(
+    uint32_t index = idasql_bookmarks_get_by_inode(
         &entry, &desc, static_cast<inode_t>(entry_path.first), nullptr);
     if (index != BOOKMARKS_BAD_INDEX && entry.place() != nullptr) {
       BookmarkRow row;

--- a/src/lib/src/types_bookmarks.cpp
+++ b/src/lib/src/types_bookmarks.cpp
@@ -72,7 +72,7 @@ void collect_local_type_bookmark_rows(std::vector<LocalTypeBookmarkRow>& rows) {
     for (const auto& ip : inode_paths) {
         lochist_entry_t e = make_ltype_loc(0);
         qstring d;
-        uint32_t slot = bookmarks_t::get_by_inode(
+        uint32_t slot = idasql_bookmarks_get_by_inode(
             &e, &d, static_cast<inode_t>(ip.first), nullptr);
         if (slot != BOOKMARKS_BAD_INDEX)
             slot_folder[slot] = {ip.first, ip.second};


### PR DESCRIPTION
Fixes #35.

## Problem
`bookmarks_t::get_by_inode()` was introduced in IDA **9.3**. The bookmark collectors referenced it directly, so building against the **9.0/9.1/9.2** SDKs failed at both **compile** (no such member) and **link** (no exported `bookmarks_t_get_by_inode`).

## Fix
Route both call sites (`symbols_bookmarks.cpp`, `types_bookmarks.cpp`) through a new `idasql_bookmarks_get_by_inode()` wrapper in `ida_compat.hpp`, gated by `IDASQL_HAS_BOOKMARKS_GET_BY_INODE (IDA_SDK_VERSION >= 930)`:

- **9.3+** → forwards to the real `bookmarks_t::get_by_inode()` (no behavior change).
- **pre-9.3** → emulates with the stable `size()` / `get()` store API.

### How the emulation works
The standard bookmark dirtrees key each leaf inode by the place's primary coordinate. Verified empirically on 9.3:
- **idaplace (EA) bookmarks:** `inode == ea` — the dirtree leaf is even named after the hex EA (e.g. `/mine/100000558`).
- **tiplace (local-type) bookmarks:** mirror this by `ordinal` (and don't get a leaf from `mark()` by default, so this path is dormant).

Both collectors only ever pass real dirtree-leaf inodes (enumerated via `collect_inode_paths`), so the shim scans the store and returns the slot whose coordinate matches the inode, leaving `out_entry`/`out_desc` populated by `get()` exactly as `get_by_inode` would. `is_place_class_ea_capable()` selects the coordinate without constructing a place (idalib doesn't export `tiplace_t`'s constructor — we only read members off places `get()` fills).

## Verification
- **Compiles + links** against SDK **9.0, 9.1, 9.2, 9.3** (9.0/9.1/9.2 previously failed at `get_by_inode`).
- **Functional parity:** forcing the emulation path on the working 9.3 runtime returns **byte-for-byte identical** `bookmarks` and `local_type_bookmarks` rows (slot / inode / address / description / folder_path / full_path) vs. the real `get_by_inode`.

No CMake changes; header-only addition plus two one-line call-site swaps.