### PR TITLE
fix(plugin): make ida_compat.hpp self-contained (include <moves.hpp>)

### DIFF
--- a/src/lib/src/ida_compat.hpp
+++ b/src/lib/src/ida_compat.hpp
@@ -19,6 +19,13 @@
 
 #pragma once
 
+// This shim references bookmarks_t / lochist_entry_t / idaplace_t / tiplace_t
+// (see idasql_bookmarks_get_by_inode below), which live in <moves.hpp>. Include
+// it directly so the shim is self-contained: ida_headers.hpp pulls moves.hpp in
+// before us, but translation units that include this header directly (e.g. the
+// plugin's main.cpp) must not depend on that ordering. (allthingsida/idasql#35)
+#include <moves.hpp>
+
 // Cutoffs empirically verified against IDA SDK headers 9.0, 9.1, 9.2, 9.3.
 //
 //  9.1 added:  tinfo_t::get_edm()/get_edm_by_value() (renamed from find_edm),


### PR DESCRIPTION
## Pre-existing build break (IDA SDK 9.3)
`idasql_plugin` failed to compile:
```
src/plugin/../lib/src/ida_compat.hpp:116: use of undeclared identifier 'bookmarks_t'
```
`idasql_cli` built fine, which is the tell.

## Root cause
`ida_compat.hpp`'s bookmarks shim (`idasql_bookmarks_get_by_inode`) uses `bookmarks_t` / `lochist_entry_t` / `idaplace_t` / `tiplace_t` from `<moves.hpp>`, but doesn't include it — it relied on `ida_headers.hpp` including `moves.hpp` (line 80) before `ida_compat.hpp` (line 102). The **plugin** (`src/plugin/main.cpp:77`) includes `ida_compat.hpp` *directly* with a curated header set (ida/idp/loader/kernwin/auto) that omits `moves.hpp`, so the type was undeclared. The CLI goes through `ida_headers.hpp`, so it never hit it.

## Fix
`#include <moves.hpp>` at the top of `ida_compat.hpp` — the shim now includes what it uses and no longer depends on include ordering. Include guards make this free for the `ida_headers.hpp` path.

## Verified
Full build clean: `xsql`, `idasql`, `idasql_cli`, **`idasql_plugin`** all built (IDA SDK 9.30). Unrelated to but discovered during allthingsida/idasql#37.