### PR TITLE
Preserve UDT layout on member delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Notes:
 | Table | Description |
 |-------|-------------|
 | `types` | Type library - structs, unions, enums with members (INSERT/UPDATE/DELETE) |
-| `types_members` | Struct/union member details (INSERT/UPDATE/DELETE) |
+| `types_members` | Struct/union member details (INSERT/UPDATE/DELETE; DELETE undefines and retains the gap) |
 | `types_enum_values` | Enum member values (INSERT/UPDATE/DELETE) |
 | `types_func_args` | Function type argument details |
 | `local_types` | Local type library entries |

--- a/prompts/idasql_agent.md
+++ b/prompts/idasql_agent.md
@@ -587,7 +587,9 @@ SELECT ordinal, name, folder_path FROM types WHERE folder_path LIKE 'idasql/type
 ```
 
 #### types_members
-Struct/union members keyed by `type_ordinal`. Full CRUD. Columns + worked examples: see the `types` skill.
+Struct/union members keyed by `type_ordinal`. Full CRUD. `DELETE` undefines the
+member and preserves the resulting layout gap, matching IDA's interactive
+behavior. Columns + worked examples: see the `types` skill.
 
 #### types_enum_values
 Enum constant values keyed by `type_ordinal`. Full CRUD. Columns + examples: see the `types` skill.

--- a/prompts/idasql_agent.md
+++ b/prompts/idasql_agent.md
@@ -475,8 +475,17 @@ INSERT INTO types (name, kind) VALUES ('my_union', 'union');
 -- Add a struct member with type
 INSERT INTO types_members (type_ordinal, member_name, member_type) VALUES (42, 'field1', 'int');
 
+-- Add a member at an explicit byte offset
+INSERT INTO types_members (type_ordinal, member_name, offset, member_type)
+VALUES (42, 'field_at_16', 16, 'int');
+
 -- Add a struct member (name only, default type)
 INSERT INTO types_members (type_ordinal, member_name) VALUES (42, 'field2');
+
+When `offset` is omitted, INSERT appends the member. For structs, a supplied
+non-negative byte offset may fit in free padding or be at/past the current
+extent; INSERT rejects ranges that overlap members. Union members must use
+offset 0.
 
 -- Add an enum value
 INSERT INTO types_enum_values (type_ordinal, value_name, value) VALUES (15, 'FLAG_ACTIVE', 1);

--- a/src/lib/src/types_members.cpp
+++ b/src/lib/src/types_members.cpp
@@ -7,8 +7,60 @@
 
 #include "types_members.hpp"
 
+#include <cctype>
+
 namespace idasql {
 namespace types {
+
+namespace {
+
+// Parse types_members type text, including suffix array forms such as char[256].
+bool parse_member_type(const std::string& type_text, tinfo_t& out_type) {
+    const std::string type = trim_copy(type_text);
+    if (type.empty()) return false;
+
+    size_t type_end = type.size();
+    std::string array_suffix;
+    while (type_end > 0 && type[type_end - 1] == ']') {
+        size_t depth = 0;
+        size_t open = type_end;
+        for (size_t i = type_end; i-- > 0;) {
+            if (type[i] == ']') {
+                ++depth;
+            } else if (type[i] == '[' && --depth == 0) {
+                open = i;
+                break;
+            }
+        }
+        if (open == type_end) return false;
+        array_suffix.insert(0, type.substr(open, type_end - open));
+        type_end = open;
+        while (type_end > 0 && std::isspace(static_cast<unsigned char>(type[type_end - 1]))) {
+            --type_end;
+        }
+    }
+
+    const std::string base_type = trim_copy(type.substr(0, type_end));
+    if (base_type.empty()) return false;
+
+    const std::string declaration = base_type + " __idasql_member" + array_suffix + ";";
+    qstring parsed_name;
+    return parse_decl(&out_type, &parsed_name, nullptr, declaration.c_str(), PT_SIL);
+}
+
+void refresh_member_type_fields(MemberEntry& entry, const udm_t& member, til_t* ti) {
+    entry.size = static_cast<int64_t>(member.size / 8);
+    entry.size_bits = static_cast<int64_t>(member.size);
+
+    qstring type_str;
+    member.type.print(&type_str);
+    entry.member_type = type_str.c_str();
+    classify_member_type(member.type, ti,
+        entry.mt_is_struct, entry.mt_is_union, entry.mt_is_enum,
+        entry.mt_is_ptr, entry.mt_is_array, entry.member_type_ordinal);
+}
+
+} // namespace
 
 int get_type_ordinal_by_name(til_t* ti, const char* type_name) {
     if (!ti || !type_name || !type_name[0]) return -1;
@@ -194,7 +246,9 @@ TypeMemberRef::TypeMemberRef(uint32_t ord) : valid(false), ordinal(ord) {
 bool TypeMemberRef::save() {
     if (!valid) return false;
     tinfo_t new_tif;
-    new_tif.create_udt(udt, tif.is_union() ? BTF_UNION : BTF_STRUCT);
+    if (!new_tif.create_udt(udt)) {
+        return false;
+    }
     return new_tif.set_numbered_type(get_idati(), ordinal, NTF_REPLACE, nullptr) == TERR_OK;
 }
 
@@ -306,9 +360,68 @@ CachedTableDef<MemberEntry> define_types_members() {
         .column_int64("size_bits", [](const MemberEntry& row) -> int64_t {
             return row.size_bits;
         })
-        .column_text("member_type", [](const MemberEntry& row) -> std::string {
-            return row.member_type;
-        })
+        .column_text_rw("member_type",
+            [](const MemberEntry& row) -> std::string {
+                return row.member_type;
+            },
+            [](MemberEntry& row, xsql::FunctionArg val) -> bool {
+                const std::string ctx = "type=" + row.type_name + " member=" + std::to_string(row.member_index);
+                if (val.is_nochange()) return true;
+                if (val.is_null()) {
+                    xsql::set_vtab_error("types_members: member_type cannot be NULL (" + ctx + ")");
+                    return false;
+                }
+
+                tinfo_t member_type;
+                const std::string type_text = val.as_text();
+                if (!parse_member_type(type_text, member_type)) {
+                    xsql::set_vtab_error("types_members: failed to parse member_type '" + type_text + "' (" + ctx + ")");
+                    return false;
+                }
+
+                const asize_t member_size = member_type.get_size();
+                if (member_size == BADSIZE) {
+                    xsql::set_vtab_error("types_members: member_type has no fixed size '" + type_text + "' (" + ctx + ")");
+                    return false;
+                }
+
+                TypeMemberRef ref(row.type_ordinal);
+                if (!ref.valid) {
+                    xsql::set_vtab_error("types_members: type not found (" + ctx + ")");
+                    return false;
+                }
+                if (row.member_index < 0 || static_cast<size_t>(row.member_index) >= ref.udt.size()) {
+                    xsql::set_vtab_error("types_members: member index out of range (" + ctx + ")");
+                    return false;
+                }
+                if (ref.udt[row.member_index].size != member_size * 8) {
+                    xsql::set_vtab_error(
+                        "types_members: member_type cannot change member size without changing UDT layout (" + ctx + ")");
+                    return false;
+                }
+
+                tinfo_t updated_tif;
+                if (!updated_tif.get_named_type(get_idati(), row.type_name.c_str())) {
+                    xsql::set_vtab_error("types_members: failed to load type for member_type update (" + ctx + ")");
+                    return false;
+                }
+                if (updated_tif.set_udm_type(static_cast<size_t>(row.member_index), member_type) != TERR_OK) {
+                    xsql::set_vtab_error("types_members: failed to update member_type (" + ctx + ")");
+                    return false;
+                }
+
+                udt_type_data_t updated_udt;
+                if (!updated_tif.get_udt_details(&updated_udt)
+                    || static_cast<size_t>(row.member_index) >= updated_udt.size()) {
+                    xsql::set_vtab_error("types_members: failed to refresh member_type (" + ctx + ")");
+                    return false;
+                }
+                const udm_t& updated_member = updated_udt[row.member_index];
+                row.offset = static_cast<int64_t>(updated_member.offset / 8);
+                row.offset_bits = static_cast<int64_t>(updated_member.offset);
+                refresh_member_type_fields(row, updated_member, get_idati());
+                return true;
+            })
         .column_int("is_bitfield", [](const MemberEntry& row) -> int {
             return row.is_bitfield ? 1 : 0;
         })
@@ -382,15 +495,17 @@ CachedTableDef<MemberEntry> define_types_members() {
                 if (mt && mt[0]) type_str = mt;
             }
             tinfo_t member_type;
-            qstring parsed_name;
-            if (parse_decl(&member_type, &parsed_name, nullptr,
-                           (type_str + " x;").c_str(), PT_SIL)) {
-                new_member.type = member_type;
-                new_member.size = member_type.get_size() * 8;
-            } else {
-                new_member.type = tinfo_t(BT_INT32);
-                new_member.size = 32;
+            if (!parse_member_type(type_str, member_type)) {
+                xsql::set_vtab_error("types_members: failed to parse member_type '" + type_str + "'");
+                return false;
             }
+            const asize_t member_size = member_type.get_size();
+            if (member_size == BADSIZE) {
+                xsql::set_vtab_error("types_members: member_type has no fixed size '" + type_str + "'");
+                return false;
+            }
+            new_member.type = member_type;
+            new_member.size = member_size * 8;
             if (argc > 11 && !argv[11].is_null()) {
                 const char* cmt = argv[11].as_c_str();
                 if (cmt) new_member.cmt = cmt;

--- a/src/lib/src/types_members.cpp
+++ b/src/lib/src/types_members.cpp
@@ -8,6 +8,7 @@
 #include "types_members.hpp"
 
 #include <cctype>
+#include <limits>
 
 namespace idasql {
 namespace types {
@@ -510,6 +511,94 @@ CachedTableDef<MemberEntry> define_types_members() {
                 const char* cmt = argv[11].as_c_str();
                 if (cmt) new_member.cmt = cmt;
             }
+
+            const bool has_explicit_offset = argc > 4 && !argv[4].is_null();
+            const bool is_union = ref.tif.is_union();
+            if (has_explicit_offset) {
+                const int64_t requested_offset = argv[4].as_int64();
+                if (requested_offset < 0) {
+                    xsql::set_vtab_error("types_members: offset must be >= 0");
+                    return false;
+                }
+                if (is_union && requested_offset != 0) {
+                    xsql::set_vtab_error("types_members: union member offset must be 0");
+                    return false;
+                }
+
+                const uint64_t offset = static_cast<uint64_t>(requested_offset);
+                const uint64_t size = static_cast<uint64_t>(member_size);
+                if (offset > std::numeric_limits<uint64_t>::max() / 8
+                    || offset > std::numeric_limits<uint64_t>::max() - size) {
+                    xsql::set_vtab_error("types_members: offset is too large");
+                    return false;
+                }
+                const uint64_t end_offset = offset + size;
+
+                const char* type_name = get_numbered_type_name(get_idati(), ordinal);
+                tinfo_t layout_tif;
+                if (!type_name || !layout_tif.get_named_type(get_idati(), type_name)) {
+                    xsql::set_vtab_error("types_members: failed to load type for member insertion");
+                    return false;
+                }
+
+                // A struct may only receive an explicitly positioned member in an
+                // explicit TAFLD_GAP member, implicit padding (reported by
+                // calc_gaps()), or at/past the current UDT extent.
+                const ssize_t best_fit_index = ref.udt.get_best_fit_member(offset);
+                bool fits_explicit_gap = false;
+                if (!is_union) {
+                    if (best_fit_index >= 0) {
+                        const udm_t& member = ref.udt[best_fit_index];
+                        const uint64_t member_offset = member.offset / 8;
+                        const uint64_t member_end = member_offset + member.size / 8;
+                        if (member.is_gap()
+                            && member_offset <= offset
+                            && end_offset <= member_end) {
+                            fits_explicit_gap = true;
+                        }
+                    }
+                    const bool extends_past_end = offset >= layout_tif.get_size();
+                    if (!fits_explicit_gap && !extends_past_end) {
+                        rangeset_t gaps;
+                        if (!layout_tif.calc_gaps(&gaps)) {
+                            xsql::set_vtab_error("types_members: failed to calculate padding gaps");
+                            return false;
+                        }
+                        if (!gaps.includes(range_t(offset, end_offset))) {
+                            xsql::set_vtab_error("types_members: offset range is not an unoccupied padding gap");
+                            return false;
+                        }
+                    }
+                }
+
+                new_member.offset = offset * 8;
+                const ssize_t insert_index = is_union ? 0
+                    : fits_explicit_gap
+                    ? best_fit_index
+                    : best_fit_index < 0 ? 0 : best_fit_index + 1;
+
+                // Edit a detached tinfo first, then persist only after the
+                // requested location survives IDA's normal layout calculation.
+                tinfo_t candidate = ref.tif;
+                if (candidate.add_udm(new_member, ETF_NO_LAYOUT, 1,
+                                      insert_index) != TERR_OK) {
+                    xsql::set_vtab_error("types_members: failed to insert member at offset");
+                    return false;
+                }
+                udm_t inserted_member;
+                if (candidate.get_udm_by_offset(&inserted_member, new_member.offset) < 0
+                    || inserted_member.is_gap()
+                    || inserted_member.name != new_member.name) {
+                    xsql::set_vtab_error("types_members: IDA could not preserve the requested offset");
+                    return false;
+                }
+                if (candidate.set_numbered_type(get_idati(), ordinal, NTF_REPLACE, nullptr) != TERR_OK) {
+                    xsql::set_vtab_error("types_members: failed to save inserted member");
+                    return false;
+                }
+                return true;
+            }
+
             if (!ref.udt.empty()) {
                 const udm_t& last = ref.udt.back();
                 new_member.offset = last.offset + last.size;

--- a/src/lib/src/types_members.cpp
+++ b/src/lib/src/types_members.cpp
@@ -469,11 +469,25 @@ CachedTableDef<MemberEntry> define_types_members() {
             return row.member_type_ordinal;
         })
         .deletable([](MemberEntry& row) -> bool {
+            const std::string ctx = "type=" + row.type_name + " member=" + std::to_string(row.member_index);
             TypeMemberRef ref(row.type_ordinal);
-            if (!ref.valid) return false;
-            if (row.member_index < 0 || static_cast<size_t>(row.member_index) >= ref.udt.size()) return false;
-            ref.udt.erase(ref.udt.begin() + row.member_index);
-            return ref.save();
+            if (!ref.valid) {
+                xsql::set_vtab_error("types_members: type not found (" + ctx + ")");
+                return false;
+            }
+            if (row.member_index < 0 || static_cast<size_t>(row.member_index) >= ref.udt.size()) {
+                xsql::set_vtab_error("types_members: member index out of range (" + ctx + ")");
+                return false;
+            }
+
+            // Use IDA's UDT editing API instead of rebuilding the member vector.
+            // The latter recalculates the layout and shifts every following member;
+            // this mirrors the UI's "undefine member" operation by retaining a gap.
+            if (ref.tif.del_udm(static_cast<size_t>(row.member_index), ETF_NO_LAYOUT) != TERR_OK) {
+                xsql::set_vtab_error("types_members: failed to undefine member (" + ctx + ")");
+                return false;
+            }
+            return true;
         })
         .insertable([](int argc, xsql::FunctionArg* argv) -> bool {
             if (argc < 4

--- a/src/lib/src/types_members.cpp
+++ b/src/lib/src/types_members.cpp
@@ -195,7 +195,7 @@ bool TypeMemberRef::save() {
     if (!valid) return false;
     tinfo_t new_tif;
     new_tif.create_udt(udt, tif.is_union() ? BTF_UNION : BTF_STRUCT);
-    return new_tif.set_numbered_type(get_idati(), ordinal, NTF_REPLACE, nullptr);
+    return new_tif.set_numbered_type(get_idati(), ordinal, NTF_REPLACE, nullptr) == TERR_OK;
 }
 
 // ============================================================================


### PR DESCRIPTION
Make `DELETE FROM types_members` mirror IDA’s Undefine workflow:
- removes the selected member without re-laying out the UDT;
- preserves its byte range as an IDA gap, so following members retain their offsets.
- Add contextual errors for invalid type/member DELETE targets.

**Verification**
Manually exercised DELETE on a disposable database:
- initial members at offsets 0, 4, 8;
- deleting the middle member produced IDA’s gap4 at offset 4;
- final member remained at offset 8; total UDT size remained 12 bytes.