### PR TITLE
manifest: add windows-aarch64 to platforms

### DIFF
--- a/ida-plugin.json.in
+++ b/ida-plugin.json.in
@@ -21,6 +21,7 @@
     "idaVersions": "@IDASQL_TARGET_IDA_VERSION@",
     "platforms": [
       "windows-x86_64",
+      "windows-aarch64",
       "linux-x86_64",
       "macos-aarch64"
     ],


### PR DESCRIPTION
IDA 9.4 has a native Windows ARM64 build. The plugin manifest listed only windows-x86_64, so an ARM64 build was not advertised for the host it runs on.
